### PR TITLE
refactor: preload background image via layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Head from "next/head";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import StarsCanvas from "@/components/main/StarsBackground";
@@ -27,6 +28,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="fr">
+      <Head>
+        <link rel="preload" href="/LooperGroup2.webp" as="image" />
+      </Head>
       <body
         className={`${inter.className} bg-[#111] overflow-y-scroll overflow-x-hidden`}
         suppressHydrationWarning

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Image from "next/image";
 import About from "@/components/About";
 import Banner from "@/components/Banner";
 import Experience from "@/components/Experience";
@@ -9,10 +10,14 @@ import Certif from "@/components/Certif";
 export default function Home() {
   return (
     <div>
-      {/* Ajoutez ceci pour précharger l'image */}
-      <link rel="preload" href="/LooperGroup2.webp" as="image"></link>
-      {/* Fin de la section préchargement */}
-      <main className="h-full w-full bg-[url('/LooperGroup2.webp')] bg-no-repeat">
+      <main className="relative h-full w-full">
+        <Image
+          src="/LooperGroup2.webp"
+          alt=""
+          fill
+          priority
+          className="object-cover -z-10"
+        />
         <div className="flex flex-col gap-20">
           <Banner />
           <About />


### PR DESCRIPTION
## Summary
- load background image through layout Head for centralized preload
- use Next.js Image component with priority to natively optimize background asset

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894ef24e3a483278fef3e916e38127a