### PR TITLE
Use environment variable for site URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables
+
+# Base URL of the site
+NEXT_PUBLIC_SITE_URL=https://portfolio-abdelali.com/
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,9 +7,10 @@ import Navbar from "@/components/Navbar";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 
 const inter = Inter({ subsets: ["latin"] });
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://portfolio-abdelali.com/";
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://portfolio-abdelali.com/"),
+  metadataBase: new URL(siteUrl),
   title: "Abdelali NOUREDDINE",
   description: "Portfolio By Abdelali NOUREDDINE",
   keywords: ["Developer", "Portfolio", "Abdelali NOUREDDINE"],
@@ -17,7 +18,7 @@ export const metadata: Metadata = {
     title: "Abdelali NOUREDDINE",
     description: "Etudiant en informatique",
     images: "/OpenGraph.jpg",
-    url: "https://portfolio-abdelali.com/",
+    url: siteUrl,
   },
 };
 


### PR DESCRIPTION
## Summary
- replace hard-coded URLs with `NEXT_PUBLIC_SITE_URL` and fallback
- document `NEXT_PUBLIC_SITE_URL` in `.env.example`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6894f4928c8c8327ae9657e77a3c013f