### PR TITLE
Refactor project listings to use mapped data

### DIFF
--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import React from "react";
+import { projects } from "@/constant";
 
 const Projects: React.FC<{}> = () => {
   return (
@@ -10,362 +11,41 @@ const Projects: React.FC<{}> = () => {
       <h1 className="text-white text-5xl font-bold text-center mb-10">
         MES PROJETS
       </h1>
-      {/* <div className="flex justify-center mt-10">
-        <a
-          href="/Tableau_competences.pdf"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="shadow-lg shadow-white z-[1] padding-20 hover:bg-white rounded-3xl text-white font-semibold hover:text-black py-3 px-10 border-[0.1px] border-white hover:border-transparent"
-        >
-          Tableau de Compétences
-        </a>
-      </div> */}
       <div className="container mx-auto">
-        <div className="flex-col flex md:flex-row mt-8">
-          <Link
-            className="z-[1] flex-1"
-            href="/projets/studentscore"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <div className="flex-row flex mb-5">
-              <Image
-                alt="StudentScore"
-                loading="lazy"
-                width={150}
-                height={150}
-                className="h-36 w-36 rounded-lg"
-                src="/projets/StudentScore.png"
-              />
-              <div className="p-3">
-                <p className="text-white font-semibold text-xl">
-                  StudentScore (C1, C4, C5)
-                </p>
-                <p className="text-gray-500 text-[10px]">
-                  Application de gestion de notes avec système de récompenses
-                  faite sous Androïd avec Android Studio.
-                </p>
+        <div className="grid md:grid-cols-2 gap-5 mt-8">
+          {projects.map((project) => (
+            <Link
+              key={project.title}
+              className="z-[1] flex-1"
+              href={project.url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <div className="flex-row flex mb-5">
+                <Image
+                  alt={project.title}
+                  loading="lazy"
+                  width={150}
+                  height={150}
+                  className="h-36 w-36 rounded-lg"
+                  src={project.image}
+                />
+                <div className="p-3">
+                  <p className="text-white font-semibold text-xl">
+                    {project.title}
+                  </p>
+                  <p className="text-gray-500 text-[10px]">
+                    {project.description}
+                  </p>
+                </div>
               </div>
-            </div>
-          </Link>
-          <Link
-            className="z-[1] flex-1"
-            href="/projets/chabis"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <div className="flex-row flex mb-5">
-              <Image
-                alt="Chabis"
-                loading="lazy"
-                width={150}
-                height={150}
-                className="h-36 w-36 rounded-lg"
-                src="/projets/php.png"
-              />
-              <div className="p-3">
-                <p className="text-white font-semibold text-xl">
-                  Chabis (C1, C4, C5)
-                </p>
-                <p className="text-gray-500 text-[10px] ">
-                  Cette application doit permettre de gérer l&apos;ensemble des
-                  chèvres de la société CHABIS, de la plus petite à la plus
-                  ancienne.
-                </p>
-              </div>
-            </div>
-          </Link>
+            </Link>
+          ))}
         </div>
-        {/* <div className="flex-col flex md:flex-row mt-8">
-          <Link
-            className="z-[1] flex-1"
-            href="/PRAPCA.pdf"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <div className="flex-row flex mb-5">
-              <Image
-                alt="PCA et PRA"
-                loading="lazy"
-                width={150}
-                height={150}
-                className="h-36 w-36 rounded-lg"
-                src="/projets/pcaPra.png"
-              />
-              <div className="p-3">
-                <p className="text-white font-semibold text-xl">
-                  PCA ET PRA (C1, C5)
-                </p>
-                <p className="text-gray-500 text-[10px] mx-[10px]">
-                  Lors de la réalisation de votre travail sur le rétablissement
-                  d&apos;un service, vous avez pu remarquer l&apos;un des
-                  risques du cloud : l&apos;indisponibilité imprévisible et
-                  incontrôlable d&apos;un service informatique.
-                </p>
-              </div>
-            </div>
-          </Link>
-
-          <Link
-            className="z-[1] flex-1"
-            href="/FicheProceduresDocker.pdf"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <div className="flex-row flex mb-5">
-              <Image
-                alt="Docker"
-                loading="lazy"
-                width={150}
-                height={150}
-                className="h-36 w-36 rounded-lg"
-                src="/projets/Docker.png"
-              />
-              <div className="p-3">
-                <p className="text-white font-semibold text-xl">
-                  Docker (C1, C5)
-                </p>
-                <p className="text-gray-500 text-[10px]">
-                  Installation et utilisation de Docker avec plusieurs exemples.
-                </p>
-              </div>
-            </div>
-          </Link>
-        </div> */}
-        <div className="flex-col flex md:flex-row mt-8">
-          <Link
-            className="z-[1] flex-1"
-            href="/projets/chl"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <div className="flex-row flex mb-5">
-              <Image
-                alt="Projet CHL"
-                loading="lazy"
-                width={150}
-                height={150}
-                className="h-26 w-26 rounded-lg"
-                src="/projets/chl.png"
-              />
-              <div className="p-3">
-                <p className="text-white font-semibold text-xl">
-                  CHL (C1, C2, C4, C5, C6)
-                </p>
-                <p className="text-gray-500 text-[10px]">
-                  Ce projet vise à créer une interface intuitive où les agents
-                  pourront facilement proposer, voter et visualiser les
-                  disponibilités, tout en assurant la sécurité et la
-                  confidentialité des données manipulées.
-                </p>
-              </div>
-            </div>
-          </Link>
-          <Link
-            className="z-[1] flex-1"
-            href="/projets/bluecom"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <div className="flex-row flex mb-5">
-              <Image
-                alt="BlueCom"
-                loading="lazy"
-                width={150}
-                height={150}
-                className="h-36 w-36 rounded-lg"
-                src="/projets/blue-com.svg"
-              />
-              <div className="p-3">
-                <p className="text-white font-semibold text-xl">
-                  BLUE COM (C1, C2, C4, C5, C6)
-                </p>
-                <p className="text-gray-500 text-[10px]">
-                  Ce projet a été la refonte du site vitrine de l&apos;agence
-                  BlueCom qui comprend un back-end en Symfony et
-                  l&apos;installation de API Platform et le front avec du
-                  NextJS.
-                </p>
-              </div>
-            </div>
-          </Link>
-        </div>
-        {/* <div className="flex-col flex md:flex-row mt-8">
-          <Link
-            className="z-[1] flex-1"
-            href="/Referencement.pdf"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <div className="flex-row flex mb-5">
-              <Image
-                alt="Projet CHL"
-                loading="lazy"
-                width={150}
-                height={150}
-                className="h-36 w-36 rounded-lg"
-                src="/projets/ref.webp"
-              />
-              <div className="p-3">
-                <p className="text-white font-semibold text-xl">
-                  Référencement Web (C3)
-                </p>
-                <p className="text-gray-500 text-[10px]">
-                  L&apos;entreprise reçoit un nouveau client dont le domaine
-                  d&apos;activité est la vente d&apos;ouvrages liés à la
-                  permaculture. Il souhaite que son site Internet soit le mieux
-                  référencé possible sur les moteurs de recherches tels que
-                  Google, ou Bing.
-                </p>
-              </div>
-            </div>
-          </Link>
-          <Link
-            className="z-[1] flex-1"
-            href="/cyberattaque.pdf"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <div className="flex-row flex mb-5">
-              <Image
-                alt="Cyberattaque"
-                loading="lazy"
-                width={150}
-                height={150}
-                className="h-30 w-36 rounded-lg"
-                src="/projets/Hacker.png"
-              />
-              <div className="p-3">
-                <p className="text-white font-semibold text-xl">
-                  Cyberattaque (C1, C2, C4, C5)
-                </p>
-                <p className="text-gray-500 text-[10px]">
-                  Le serveur de l&apos;entreprise OmniWeb a subi une
-                  cyberattaque d&apos;une ampleur inédite, un vendredi à 17
-                  heures. Après évaluation des dégâts, le choix est fait de
-                  réinstaller l&apos;intégralité des services sur le serveur de
-                  secours, en partant de 0.
-                </p>
-              </div>
-            </div>
-          </Link>
-        </div> */}
-        {/* <div className="flex-col flex md:flex-row mt-8">
-          <Link
-            className="z-[1] flex-1"
-            href="/Wordpress.pdf"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <div className="flex-row flex mb-5">
-              <Image
-                alt="WordPresse"
-                loading="lazy"
-                width={150}
-                height={150}
-                className="h-36 w-36 rounded-lg"
-                src="/projets/wordpress.png"
-              />
-              <div className="p-3">
-                <p className="text-white font-semibold text-xl">
-                  Référencement WordPresse (C3, C5)
-                </p>
-                <p className="text-gray-500 text-[10px]">
-                  L&apos;entreprise reçoit un nouveau client dont le domaine
-                  d&apos;activité est la vente d&apos;ouvrages liés à la
-                  permaculture. Il souhaite que son site Internet soit le mieux
-                  référencé possible sur les moteurs de recherches tels que
-                  Google, ou Bing.
-                </p>
-              </div>
-            </div>
-          </Link>
-          <Link
-            className="z-[1] flex-1"
-            href="/Robots.pdf"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <div className="flex-row flex mb-5">
-              <Image
-                alt="Robot"
-                loading="lazy"
-                width={150}
-                height={150}
-                className="h-30 w-36 rounded-lg"
-                src="/projets/robots.webp"
-              />
-              <div className="p-3">
-                <p className="text-white font-semibold text-xl">
-                  Robots.txt (C5)
-                </p>
-                <p className="text-gray-500 text-[10px]">
-                  Le serveur de l&apos;entreprise OmniWeb a subi une
-                  cyberattaque d&apos;une ampleur inédite, un vendredi à 17
-                  heures. Après évaluation des dégâts, le choix est fait de
-                  réinstaller l&apos;intégralité des services sur le serveur de
-                  secours, en partant de 0.
-                </p>
-              </div>
-            </div>
-          </Link>
-        </div> */}
-        {/* <div className="flex-col flex md:flex-row mt-8">
-          <Link
-            className="z-[1] flex-1"
-            href="https://portfolio-abdelali.com/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <div className="flex-row flex mb-5">
-              <Image
-                alt="Portfolio"
-                loading="lazy"
-                width={150}
-                height={150}
-                className="h-36 w-36 rounded-lg"
-                src="/projets/portfolio.webp"
-              />
-              <div className="p-3">
-                <p className="text-white font-semibold text-xl">
-                  Portfolio (C3, C5)
-                </p>
-                <p className="text-gray-500 text-[15px]">
-                  Ici c&apos;est mon portfolio 😜
-                </p>
-              </div>
-            </div>
-          </Link>
-          <Link
-            className="z-[1] flex-1"
-            href="/projets/veille"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <div className="flex-row flex mb-5">
-              <Image
-                alt="Veille"
-                loading="lazy"
-                width={150}
-                height={150}
-                className="h-30 w-36 rounded-lg"
-                src="/projets/veille.png"
-              />
-              <div className="p-3">
-                <p className="text-white font-semibold text-xl">
-                  Veille Technologique (C5)
-                </p>
-                <p className="text-gray-500 text-[10px]">
-                  Ici ma technique pour la veille technologique choisi par moi
-                  même
-                </p>
-              </div>
-            </div>
-          </Link>
-        </div> */}
       </div>
     </section>
   );
 };
 
 export default Projects;
+

--- a/constant/index.tsx
+++ b/constant/index.tsx
@@ -15,3 +15,34 @@ export const Social_Icons = [
     alt: "LinkedIn",
   },
 ];
+
+export const projects = [
+  {
+    title: "StudentScore (C1, C4, C5)",
+    description:
+      "Application de gestion de notes avec système de récompenses faite sous Androïd avec Android Studio.",
+    image: "/projets/StudentScore.png",
+    url: "/projets/studentscore",
+  },
+  {
+    title: "Chabis (C1, C4, C5)",
+    description:
+      "Cette application doit permettre de gérer l'ensemble des chèvres de la société CHABIS, de la plus petite à la plus ancienne.",
+    image: "/projets/php.png",
+    url: "/projets/chabis",
+  },
+  {
+    title: "CHL (C1, C2, C4, C5, C6)",
+    description:
+      "Ce projet vise à créer une interface intuitive où les agents pourront facilement proposer, voter et visualiser les disponibilités, tout en assurant la sécurité et la confidentialité des données manipulées.",
+    image: "/projets/chl.png",
+    url: "/projets/chl",
+  },
+  {
+    title: "BLUE COM (C1, C2, C4, C5, C6)",
+    description:
+      "Ce projet a été la refonte du site vitrine de l'agence BlueCom qui comprend un back-end en Symfony et l'installation de API Platform et le front avec du NextJS.",
+    image: "/projets/blue-com.svg",
+    url: "/projets/bluecom",
+  },
+];


### PR DESCRIPTION
## Summary
- move project metadata into a reusable `projects` array
- render project cards by mapping over the array and drop commented sections

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6894f493ceb08327be8014ee1d29aa16