### PR TITLE
Replace window open with anchors and secure external links

### DIFF
--- a/app/projets/bluecom/page.tsx
+++ b/app/projets/bluecom/page.tsx
@@ -40,7 +40,8 @@ const CHL = () => {
             onClick={() =>
               window.open(
                 "https://gitlab.com/abdelcorps/site_blue_com",
-                "_blank"
+                "_blank",
+                "noopener,noreferrer"
               )
             }
             className="px-4 py-2 bg-black text-white rounded-lg shadow-lg hover:bg-gray-700 mb-4"
@@ -48,14 +49,20 @@ const CHL = () => {
             Code source du site
           </button>
           <button
-            onClick={() => window.open("https://blue-com.fr/", "_blank")}
+            onClick={() =>
+              window.open("https://blue-com.fr/", "_blank", "noopener,noreferrer")
+            }
             className="px-4 py-2 bg-black text-white rounded-lg shadow-lg hover:bg-gray-700 mb-4 ml-5"
           >
             Ancien site
           </button>
           <button
             onClick={() =>
-              window.open("https://phebus-energie.com/login", "_blank")
+              window.open(
+                "https://phebus-energie.com/login",
+                "_blank",
+                "noopener,noreferrer"
+              )
             }
             className="px-4 py-2 bg-black text-white rounded-lg shadow-lg hover:bg-gray-700 mb-4 ml-5"
           >

--- a/app/projets/chabis/page.tsx
+++ b/app/projets/chabis/page.tsx
@@ -59,7 +59,8 @@ const Chabis = () => {
             onClick={() =>
               window.open(
                 "https://gitea.btssio-poitiers.fr/chabis_3/chabis_Project_3",
-                "_blank"
+                "_blank",
+                "noopener,noreferrer"
               )
             }
             className="px-4 py-2 bg-black text-white rounded-lg shadow-lg hover:bg-gray-700 mb-4"

--- a/app/projets/chl/page.tsx
+++ b/app/projets/chl/page.tsx
@@ -44,7 +44,8 @@ const CHL = () => {
             onClick={() =>
               window.open(
                 "https://portail.ch-poitiers.fr/rendez-vous/GYIDTILF/",
-                "_blank"
+                "_blank",
+                "noopener,noreferrer"
               )
             }
             className="px-4 py-2 bg-black text-white rounded-lg shadow-lg hover:bg-gray-700 mb-4"

--- a/app/projets/studentscore/page.tsx
+++ b/app/projets/studentscore/page.tsx
@@ -118,7 +118,8 @@ const StudentScore = () => {
             onClick={() =>
               window.open(
                 "https://gitea.btssio-poitiers.fr/ANDROID_P3_TEAM/ANDROID_P3_NOTE",
-                "_blank"
+                "_blank",
+                "noopener,noreferrer"
               )
             }
             className="px-4 py-2 bg-black text-white rounded-lg shadow-lg hover:bg-gray-700 mb-4"

--- a/components/Banner.tsx
+++ b/components/Banner.tsx
@@ -32,20 +32,19 @@ export default function Banner() {
           </p>
         </div>
         <div className="pb-12 text-md flex justify-center gap-8 mb-12">
-          <button
-            onClick={() =>
-              window.open("mailto:abdelali.noureddine86@gmail.com")
-            }
+          <a
+            href="mailto:abdelali.noureddine86@gmail.com"
             className="shadow-lg shadow-white z-[1] padding-20  hover:bg-white rounded-3xl text-white font-semibold hover:text-black py-3 px-10 border-[0.1px] border-white hover:border-transparent "
           >
             Me contacter
-          </button>
-          <button
-            onClick={() => window.open("/CV.pdf", "_blank")}
+          </a>
+          <a
+            href="/CV.pdf"
+            download
             className="shadow-lg shadow-white z-[1] padding-20 hover:bg-white rounded-3xl text-white font-semibold hover:text-black py-3 px-10 border-[0.1px] border-white hover:border-transparent"
           >
             Télécharger mon CV
-          </button>
+          </a>
         </div>
       </div>
     </div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -20,14 +20,12 @@ const Navbar: React.FC<{}> = () => {
         </Link>
 
         <div className="flex flex-row gap-5">
-          <div
-            onClick={() =>
-              window.open("mailto:abdelali.noureddine86@gmail.com")
-            }
+          <a
+            href="mailto:abdelali.noureddine86@gmail.com"
             className=" z-[1] bg-transparent  padding-10 cursor-pointer bg-black hover:bg-[#2E2E2E] rounded-xl  text-white  py-2 px-5"
           >
             Contact
-          </div>
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- replace email button with mailto anchors
- use download link for CV instead of window.open
- secure external links with `noopener` and `noreferrer`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894f49656988327a7a536c5a11542ab